### PR TITLE
fix error on cut

### DIFF
--- a/src/cactus.js
+++ b/src/cactus.js
@@ -88,7 +88,7 @@ async function cutReleaseBranch(args) {
   await clonedRepo.push('origin', `master:${versionInfo.releaseBranchName}`);
   await clonedRepo.pushTags('origin');
   // Note that this is the original repo, not the cloned repo
-  await repo.pull(args.upstream, '', { '--rebase': null });
+  await repo.pull(args.upstream, { '--rebase': null });
 
   return 'Done!';
 }


### PR DESCRIPTION
This fixes an issue where the `git cactus cut` operations would complete successfully and
then fail with the error `fatal: no path specified; see 'git help pull' for valid url syntax` when updating the repo afterwards so it's up to date with the remote.